### PR TITLE
stm32f4_disco: workaround user button polarity issues in upstream DTS

### DIFF
--- a/boards/stm32f4_disco.overlay
+++ b/boards/stm32f4_disco.overlay
@@ -35,6 +35,11 @@
   gpio_keys {
     compatible = "gpio-keys";
 
+    user_button: button {
+      gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
+      label = "Key";
+    };
+
     button_north {
       gpios = <&gpioe 7 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
       label = "North Button";

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -122,7 +122,6 @@ bool input_get_raw_state(RawInputState* out) {
     const char* device_name = DT_GPIO_KEYS_##GPIO_NAME##_GPIOS_CONTROLLER;                 \
     uint8_t device_index = gpio_indices[index];                                            \
     constexpr uint32_t flags = DT_GPIO_KEYS_##GPIO_NAME##_GPIOS_FLAGS;                     \
-    static_assert((flags & GPIO_ACTIVE_LOW) || (flags & GPIO_ACTIVE_HIGH));                \
     bool value = port_values[device_index] & (1U << DT_GPIO_KEYS_##GPIO_NAME##_GPIOS_PIN); \
     if constexpr (flags & GPIO_ACTIVE_LOW) {                                               \
       out->gpio_name = !value;                                                             \


### PR DESCRIPTION
Also removes the static_assert around GPIO polarity since it doesn't make sense to check for a bit to be either 1 or 0.