### PR TITLE
Properly define the DFU button for STM32 Discovery

### DIFF
--- a/scripts/boards.sh
+++ b/scripts/boards.sh
@@ -63,11 +63,14 @@ elif [[ "$BOARD" == "stm32f4_disco" ]]; then
   PL_PYOCD_TYPE=stm32f407vg
 
   PL_MCUBOOT_SUPPORTED=1
+  # Use GPIO E7 ("Up key") here because the "User" button needs internal
+  # pull-down, which is not yet supported on MCUBoot (and I'm too lazy to add
+  # it).
   PL_MCUBOOT_OPTS="
     -DCONFIG_LOG=n
     -DCONFIG_BOOT_USB_DFU_GPIO=y
-    -DCONFIG_BOOT_USB_DFU_DETECT_PORT=\"GPIO_0\"
-    -DCONFIG_BOOT_USB_DFU_DETECT_PIN=0
+    -DCONFIG_BOOT_USB_DFU_DETECT_PORT=\"GPIOE\"
+    -DCONFIG_BOOT_USB_DFU_DETECT_PIN=7
   "
 else
   echo "warning: unsupported board: \"$BOARD\" (edit scripts/boards.sh?)"


### PR DESCRIPTION
The GPIO port was previously defined as`GPIO_0`, which is invalid for STM32 and causes the bootloader to crash. Change it to `GPIOE` and change the pin # to 7 so holding down GPIO E7 (aka the "Up" key defined in PassingLink for STM32F4 Discovery) enters the DFU mode.

Fixes #20.